### PR TITLE
Fix meteor installer extraction

### DIFF
--- a/.nbx/web/Dockerfile
+++ b/.nbx/web/Dockerfile
@@ -19,8 +19,17 @@ RUN apt-get install -y \
       runit \
       curl
 
-# install meteor
-RUN curl https://install.meteor.com/ | sh
+# install meteor - meteor installer doesn't work with the default tar binary
+# see https://github.com/coreos/bugs/issues/1095
+RUN apt-get install -y bsdtar \
+    && cp $(which tar) $(which tar)~ \
+    && ln -sf $(which bsdtar) $(which tar)
+
+# install Meteor forcing its progress
+RUN curl "https://install.meteor.com/" | sh
+
+# put back the original tar
+RUN mv $(which tar)~ $(which tar)
 
 # install node
 RUN \


### PR DESCRIPTION
I was seeing the error "Directory renamed before its status could be extracted" when trying to run `nxb push`.

Full error output:
```
Removing intermediate container 1d53bf3c0ad5
 ---> e471dbdc41bf
Step 8/19 : RUN curl https://install.meteor.com/ | sh
 ---> Running in 1842b5681e6b
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7786    0  7786    0     0   8300      0 --:--:-- --:--:-- --:--:--  8291
Downloading Meteor distribution
tar: .meteor/packages/babel-compiler/.7.1.1.lkrc35.nn42i++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/regjsparser/node_modules/.bin: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.1.1.lkrc35.nn42i++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/regjsparser/node_modules: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.1.1.lkrc35.nn42i++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/regjsparser: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.1.1.lkrc35.nn42i++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/.bin: Directory renamed before its status could be extracted
tar: Exiting with failure status due to previous errors
The command '/bin/sh -c curl https://install.meteor.com/ | sh' returned a non-zero code: 2

⣾ ⠕◳⠪ ⣷                                                              CLEANING UP
--------------------------------------------------------------------------------

[ ✓ ] COMPLETE!

There was an error running the command:

nbx.Push: building image 'web-1533141687': exit status 2
```

I found this related issue: https://github.com/coreos/bugs/issues/1095

The fix there worked for me, it replaces:
`RUN curl https://install.meteor.com/ | sh`

with:

```
RUN apt-get install -y bsdtar \
    && cp $(which tar) $(which tar)~ \
    && ln -sf $(which bsdtar) $(which tar)

# install Meteor forcing its progress
RUN curl "https://install.meteor.com/" | sh

# put back the original tar
RUN mv $(which tar)~ $(which tar)
```